### PR TITLE
Update encoding on setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ CLASSIFIERS = [
     'Operating System :: MacOS'
 ]
 
-with open('README.rst') as file:
+with open('README.rst',encoding='utf8') as file:
     long_description = file.read()
 
 setup(


### PR DESCRIPTION
Windows installation fails due to mismatched encoding.
Error message:     `UnicodeDecodeError: 'charmap' codec can't decode byte 0x9c in position 795: character maps to <undefined>`

Defining a utf8 encoding fixes the error and the installation finishes without any errors or warnings.

